### PR TITLE
Don't hide if the tooltip isn't ready.

### DIFF
--- a/tooltipsy.source.js
+++ b/tooltipsy.source.js
@@ -126,6 +126,10 @@
     $.tooltipsy.prototype.hide = function (e) {
         var base = this;
 
+        if (base.ready === false) {
+            return;
+        }
+
         if (e && e.relatedTarget === base.$tip[0]) {
             base.$tip.bind('mouseleave', function (e) {
                 if (e.relatedTarget === base.$el[0]) {


### PR DESCRIPTION
I found that hide was being called-back before show (and thus readify()). This protects against that case.

I think its best simply to bail in this case, rather than call readify() and continue.
