### PR TITLE
A fix in the destroy function, sometimes occurs an error.

### DIFF
--- a/tooltipsy.source.js
+++ b/tooltipsy.source.js
@@ -196,7 +196,12 @@
     };
 
     $.tooltipsy.prototype.destroy = function () {
-        this.$tipsy.remove();
+        if(this.$tipsy)
+            this.$tipsy.remove();
+        else {
+            window.clearTimeout(this.delaytimer);
+            this.delaytimer=null;
+        }
         $.removeData(this.$el, 'tooltipsy');
     };
 


### PR DESCRIPTION
Update on destroy function. If you try to destroy a tooltip after it's been triggered to appear but before the show delay, you get an error because it wasn't created yet.
